### PR TITLE
Update multi-tenant capability

### DIFF
--- a/locations/models.py
+++ b/locations/models.py
@@ -178,7 +178,8 @@ class LocationTagIndexPage(Page):
 
         # Filter by tag
         tag = request.GET.get('tag')
-        locationpages = LocationPage.objects.filter(tags__name=tag).live()
+        locationsindexset= LocationsIndexPage.objects.live().parent_of(self)
+        locationpages = LocationPage.objects.filter(tags__name=tag).live().descendant_of(locationsindexset[0])
 
         # Update template context
         context = super().get_context(request)

--- a/locations/models.py
+++ b/locations/models.py
@@ -77,8 +77,7 @@ class LocationsIndexPage(Page):
                         if d <= self.max_dist_km:
                             locationsnearme.append(page)
         context['locationsnearme'] = locationsnearme
-        locationtagindexset=LocationTagIndexPage.objects.live().child_of(self)
-        context['tagspage']=locationtagindexset[0]
+        context['tagspage'] = LocationTagIndexPage.objects.live().child_of(self).first()
         return context
 
     content_panels = Page.content_panels + [
@@ -164,8 +163,7 @@ class LocationPage(Page):
 
     def get_context(self, request):
         context = super().get_context(request)
-        locationtagindexset=LocationTagIndexPage.objects.live().sibling_of(self)
-        context["tagspage"]=locationtagindexset[0]
+        context['tagspage'] = LocationTagIndexPage.objects.live().child_of(LocationsIndexPage.objects.live().ancestor_of(self).first()).first()
         return context
 
 class LocationPageGalleryImage(Orderable):
@@ -186,8 +184,7 @@ class LocationTagIndexPage(Page):
 
         # Filter by tag
         tag = request.GET.get('tag')
-        locationsindexset= LocationsIndexPage.objects.live().parent_of(self)
-        locationpages = LocationPage.objects.filter(tags__name=tag).live().descendant_of(locationsindexset[0])
+        locationpages = LocationPage.objects.filter(tags__name=tag).live().descendant_of(self.get_parent())
 
         # Update template context
         context = super().get_context(request)

--- a/locations/models.py
+++ b/locations/models.py
@@ -77,6 +77,8 @@ class LocationsIndexPage(Page):
                         if d <= self.max_dist_km:
                             locationsnearme.append(page)
         context['locationsnearme'] = locationsnearme
+        locationtagindexset=LocationTagIndexPage.objects.live().child_of(self)
+        context['tagspage']=locationtagindexset[0]
         return context
 
     content_panels = Page.content_panels + [

--- a/locations/models.py
+++ b/locations/models.py
@@ -162,6 +162,12 @@ class LocationPage(Page):
         )
     ]
 
+    def get_context(self, request):
+        context = super().get_context(request)
+        locationtagindexset=LocationTagIndexPage.objects.live().sibling_of(self)
+        context["tagspage"]=locationtagindexset[0]
+        return context
+
 class LocationPageGalleryImage(Orderable):
     page = ParentalKey(LocationPage, on_delete=models.CASCADE, related_name='gallery_images')
     image = models.ForeignKey(

--- a/locations/models.py
+++ b/locations/models.py
@@ -77,6 +77,7 @@ class LocationsIndexPage(Page):
                         if d <= self.max_dist_km:
                             locationsnearme.append(page)
         context['locationsnearme'] = locationsnearme
+        # the first tag index page which is a child of this page
         context['tagspage'] = LocationTagIndexPage.objects.live().child_of(self).first()
         return context
 
@@ -163,6 +164,7 @@ class LocationPage(Page):
 
     def get_context(self, request):
         context = super().get_context(request)
+        # the first tag index page which is a child of the parent location index of this page
         context['tagspage'] = LocationTagIndexPage.objects.live().child_of(LocationsIndexPage.objects.live().ancestor_of(self).first()).first()
         return context
 
@@ -184,6 +186,7 @@ class LocationTagIndexPage(Page):
 
         # Filter by tag
         tag = request.GET.get('tag')
+        # the location pages which are descendants of the parent page
         locationpages = LocationPage.objects.filter(tags__name=tag).live().descendant_of(self.get_parent())
 
         # Update template context

--- a/locations/templates/locations/location_page.html
+++ b/locations/templates/locations/location_page.html
@@ -68,7 +68,7 @@
                 <div class="text-center mt-3">
                     <h5>Tags</h5>
                     {% for tag in page.tags.all %}
-                        <a href="{{ page.get_parent.url }}{{ tagspage.slug }}?tag={{ tag }}" class="btn btn-primary">{{ tag | title }}</a>
+                        <a href="{{ tagspage.get_url }}?tag={{ tag }}" class="btn btn-primary">{{ tag | title }}</a>
                     {% endfor %}
                 </div>
             </div>

--- a/locations/templates/locations/location_page.html
+++ b/locations/templates/locations/location_page.html
@@ -68,7 +68,7 @@
                 <div class="text-center mt-3">
                     <h5>Tags</h5>
                     {% for tag in page.tags.all %}
-                        <a href="{% slugurl 'tags' %}?tag={{ tag }}" class="btn btn-primary">{{ tag | title }}</a>
+                        <a href="{{ page.get_parent.url }}{{ tagspage.slug }}?tag={{ tag }}" class="btn btn-primary">{{ tag | title }}</a>
                     {% endfor %}
                 </div>
             </div>

--- a/locations/templates/locations/locations_index_page.html
+++ b/locations/templates/locations/locations_index_page.html
@@ -43,7 +43,7 @@
                     <div class="content-title-holder anm fdu">
                         <h2 class="ml-4">{{ tag | title }}</h2>
                         {% if tagspage %}
-		            <a class="a-color" href="{{ tagspage.slug }}?tag={{ tag }}"><p class="mr-3  mt-3">See all</p></a>
+                            <a class="a-color" href="{{ tagspage.slug }}?tag={{ tag }}"><p class="mr-3  mt-3">See all</p></a>
                         {% endif %}
                     </div>
                     <div class="swiper-container">

--- a/locations/templates/locations/locations_index_page.html
+++ b/locations/templates/locations/locations_index_page.html
@@ -42,7 +42,9 @@
                 <div class="tag-content mb-4">
                     <div class="content-title-holder anm fdu">
                         <h2 class="ml-4">{{ tag | title }}</h2>
-                        <a class="a-color" href="{% slugurl 'tags' %}?tag={{ tag }}"><p class="mr-3  mt-3">See all</p></a>
+                        {% if tagspage %}
+		            <a class="a-color" href="{{ tagspage.slug }}?tag={{ tag }}"><p class="mr-3  mt-3">See all</p></a>
+                        {% endif %}
                     </div>
                     <div class="swiper-container">
                         <div class="swiper-wrapper">

--- a/locations/templates/locations/locations_index_page.html
+++ b/locations/templates/locations/locations_index_page.html
@@ -43,7 +43,7 @@
                     <div class="content-title-holder anm fdu">
                         <h2 class="ml-4">{{ tag | title }}</h2>
                         {% if tagspage %}
-                            <a class="a-color" href="{{ tagspage.slug }}?tag={{ tag }}"><p class="mr-3  mt-3">See all</p></a>
+                            <a class="a-color" href="{{ tagspage.get_url }}?tag={{ tag }}"><p class="mr-3  mt-3">See all</p></a>
                         {% endif %}
                     </div>
                     <div class="swiper-container">


### PR DESCRIPTION
Fixes most of the problems regarding LocationsIndexPage and LocationTagsIndexPage sharing children pages via redirects without permission.

This would become a problem should customers have their tags button redirect users to an exhaustive index of all premio cms pages which have that tag.